### PR TITLE
Fix error in handling of Feedback object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digitalocean/functions-deployer",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "The the functions deployer for DigitalOcean",
   "main": "lib/index.js",
   "repository": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -291,7 +291,7 @@ export async function deployProject(project: string, cmdFlags: Flags, creds: Cre
     feedback = new LoggerFeedback(new CaptureLogger())
     feedback.warnOnly = true
   } else {
-    feedback = new LoggerFeedback(new DefaultLogger())
+    feedback = new LoggerFeedback(logger)
   }
 
   let todeploy = await readAndPrepare(project, creds, cmdFlags, feedback)


### PR DESCRIPTION
The way the Feedback object was being handled in the new main interface allowed things to leak to the console when invoked via the library interface.   The intent is that nothing shall leak when that interface is used.