### PR TITLE
Add packaged install for downloading into runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 lib
 node_modules
-digitalocean-functions-deployer*.tgz
+*.tgz
 *.bak
+dosls

--- a/bootstrap
+++ b/bootstrap
@@ -1,0 +1,6 @@
+#/bin/bash
+SELF="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SELF
+./node ./node_modules/.bin/dosls $*
+
+

--- a/internalRelease.sh
+++ b/internalRelease.sh
@@ -2,17 +2,25 @@
 
 # Creates and uploads a build of the deployer for incorporation into other DigitalOcean tools.
 
+# Two artifacts are uploaded.
+# 1. A tarball resulting from 'npm pack' and suitable for installation as a dependency.
+# 2. A complete installation tarball for ubuntu (suitable for incorporating dosls into runtimes).
+
 # Change these variables on changes to the space we are uploading to or naming conventions within it
 TARGET_SPACE=do-serverless-tools
 DO_ENDPOINT=nyc3.digitaloceanspaces.com
 SPACE_URL="https://$TARGET_SPACE.$DO_ENDPOINT"
 TARBALL_NAME_PREFIX="digitalocean-functions-deployer"
-TARBALL_NAME_SUFFIX="tgz"
 
 # Change this variable when local setup for s3 CLI access changes
 # This assumes the developer has a profile 'do' with the appropriate access keys for
 # carrying out this operaiton.
 AWS="aws --profile do --endpoint https://$DO_ENDPOINT"
+
+# This node download URL should match what doctl sls install would install for linux amd
+nodeVersion="v16.13.0"
+nodeDir="node-${nodeVersion}-linux-x64"
+NODE_DOWNLOAD=https://nodejs.org/dist/${nodeVersion}/${nodeDir}.tar.gz
 
 SELFDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SELFDIR
@@ -20,10 +28,14 @@ cd $SELFDIR
 echo "Determining the version"
 VERSION=$(jq -r .version < package.json)
 echo "New version is $VERSION"
-TARBALL_NAME="$TARBALL_NAME_PREFIX-$VERSION.$TARBALL_NAME_SUFFIX"
-echo "New tarball name is $TARBALL_NAME"
 
-echo "Checking whether the new (?) tarball is already uploaded"
+# Name the tarballs
+TARBALL_NAME="$TARBALL_NAME_PREFIX-$VERSION.tgz"
+FAT_TARBALL_NAME="dosls-$VERSION.tgz"
+echo "The dependency tarball is $TARBALL_NAME"
+echo "The complete install tarball for Linux is $FAT_TARBALL_NAME"
+
+echo "Checking whether this version is already uploaded"
 UPLOADED=$($AWS s3api head-object --bucket "$TARGET_SPACE" --key "$TARBALL_NAME")
 if [ "$?" == "0" ]; then
   echo "$TARBALL_NAME has already been built and uploaded.  Skipping remaining steps."
@@ -38,9 +50,33 @@ rm -rf lib node_modules *.tgz
 echo "Ensuring a full install"
 npm install
 
-echo "Building the tarball"
+echo "Building the simple tarball"
 npm pack
 
-echo "Uploading"
+echo "Uploading the simple tarball"
 $AWS s3 cp "$TARBALL_NAME" "s3://$TARGET_SPACE/$TARBALL_NAME"
 $AWS s3api put-object-acl --bucket "$TARGET_SPACE" --key "$TARBALL_NAME" --acl public-read
+
+echo "Creating node_modules for the full install"
+rm -fr dosls
+mkdir dosls
+cd dosls
+cp ../package.json .
+npm install --production ../$TARBALL_NAME
+rm *.json
+
+echo "Downloading node binary suitable for runtime use"
+curl -L $NODE_DOWNLOAD | tar xzf -
+mv ${nodeDir}/bin/node .
+rm -fr ${nodeDir}
+
+echo "Adding bootstrap"
+cp ../bootstrap .
+
+echo "Making the installation tarball (linux amd64 only)"
+cd ..
+tar czf "$FAT_TARBALL_NAME" dosls
+
+echo "Uploading the installation tarball"
+$AWS s3 cp "$FAT_TARBALL_NAME" "s3://$TARGET_SPACE/$FAT_TARBALL_NAME"
+$AWS s3api put-object-acl --bucket "$TARGET_SPACE" --key "$FAT_TARBALL_NAME" --acl public-read

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digitalocean/functions-deployer",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "The the functions deployer for DigitalOcean",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
This change expands the "internal release" script so that, in addition to creating a simple tarball for installation as a dependency (to be used by the doctl serverless plugin) it also makes a full install package for linux amd64 (designed to be downloaded and installed in the runtimes to support remote build).