### PR TITLE
Include proper path in building messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digitalocean/functions-deployer",
-      "version": "5.0.6",
+      "version": "5.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "The the functions deployer for DigitalOcean",
   "main": "lib/index.js",
   "repository": {

--- a/src/project-reader.ts
+++ b/src/project-reader.ts
@@ -266,7 +266,7 @@ function buildActionsPart(pkgsdir: string, displayPath: string, includer: Includ
   if (!pkgsdir) {
     return Promise.resolve(emptyStructure())
   } else {
-    return buildPkgArray(pkgsdir, displayPath, includer, reader).then((values) => {
+    return buildPkgArray(pkgsdir, displayPath + "/packages", includer, reader).then((values) => {
       const [strays, pkgs] = values
       return { web: [], packages: pkgs, strays: strays }
     })


### PR DESCRIPTION
This addresses a minor bug whereby the directory `/packages` is omitted from paths when reporting on the progress of builds (and possibly other contexts).  Also allow for testing of the release script without uploading.