### PR TITLE
Fix a stupid typo in bootstrap script

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 REAL=$(readlink -f "${BASH_SOURCE[0]}")
 SELF=$(dirname "$REAL")
 "$SELF/node" "$SELF/node_modules/.bin/dosls" $*


### PR DESCRIPTION
I left the bang out of the hashbang.  This basically doesn't matter when invoking from a shell or another shell script, but, at system exec level (e.g. invoking from the python builder action) it does.