### PR TITLE
Ensure error reporting is correct when capturing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digitalocean/functions-deployer",
-      "version": "5.0.8",
+      "version": "5.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "description": "The the functions deployer for DigitalOcean",
   "main": "lib/index.js",
   "repository": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,7 +298,7 @@ export async function deployProject(project: string, cmdFlags: Flags, creds: Cre
   if (!todeploy) {
     return false
   } else if (todeploy.error && !cmdFlags.json) {
-    console.error(todeploy.error)
+    logger.displayError('', todeploy.error)
     return false
   }
   if (!watching && !todeploy.slice && !cmdFlags.json) {


### PR DESCRIPTION
Changing a `console.error` call that shouldn't be there into a proper `logger.displayError` call so that capturing of output in structured form will work as intended.   The incorrect logic was causing error information to "leak" from the plugin and confuse `doctl`.  