### PR TITLE
Remove early exit on deploy failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.9",
+  "version": "5.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digitalocean/functions-deployer",
-      "version": "5.0.9",
+      "version": "5.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.9",
+  "version": "5.0.10",
   "description": "The the functions deployer for DigitalOcean",
   "main": "lib/index.js",
   "repository": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ export class DefaultLogger implements Logger {
     console.log(JSON.stringify(entity, null, 2))
   }
 
-  logTable(data: Record<string, unknown>[], columns: Record<string, unknown>, options: Record<string, unknown> = {}): void {
+  logTable(data: Record<string, unknown>[], _columns: Record<string, unknown>, _options: Record<string, unknown> = {}): void {
     console.log(JSON.stringify(data, null, 2))
   }
 
@@ -79,10 +79,7 @@ export class DefaultLogger implements Logger {
 
 // An alternative Logger for capturing output
 export class CaptureLogger implements Logger {
-  command: string[] // The oclif command sequence being captured (aio only)
   table: Record<string, unknown>[] // The output table (array of entity) if that kind of output was produced
-  tableColumns: Record<string, unknown> // The column definition needed to format the table with cli-ux
-  tableOptions: Record<string, unknown> // The options definition needed to format the table with cli-ux
   captured: string[] = [] // Captured line by line output (flowing via Logger.log)
   errors: string[] = [] // Captured calls to displayError (these are Errors that are not supposed to be thrown)
   entity: Record<string, unknown> // An output entity if that kind of output was produced
@@ -114,10 +111,8 @@ export class CaptureLogger implements Logger {
     this.entity = entity
   }
 
-  logTable(data: Record<string, unknown>[], columns: Record<string, unknown>, options: Record<string, unknown> = {}): void {
+  logTable(data: Record<string, unknown>[], _columns: Record<string, unknown>, _options: Record<string, unknown> = {}): void {
     this.table = data
-    this.tableColumns = columns
-    this.tableOptions = options
   }
 
   logOutput(json: Record<string, unknown>, msgs: string[]): void {
@@ -213,9 +208,7 @@ export async function runCommand(inputArgs: string[], logger: Logger) {
 async function doDeploy(project: string, flags: Flags, logger: Logger): Promise<void> {
     const { insecure, apiHost: apihost, auth } = flags
     const creds = await processCredentials(insecure, apihost, auth)
-    if (!await deployProject(project, flags, creds, false, logger)) {
-      process.exit(1)
-    }
+    await deployProject(project, flags, creds, false, logger)
 }
 
 // Command to retrieve project description metadata
@@ -362,7 +355,7 @@ function displayJSONResult(outcome: DeployResponse, logger: Logger, feedback: an
 }
 
 // Display the result of a successful run
-function displayResult(result: DeployResponse, watching: boolean, logger: Logger): boolean {
+function displayResult(result: DeployResponse, _watching: boolean, logger: Logger): boolean {
   let success = true
   if (result.successes.length === 0 && result.failures.length === 0) {
     logger.log('\nNothing deployed')


### PR DESCRIPTION
This change removes an explicit process exit that should not have been there.

The exit did not really matter when using `dosls` as a CLI because everything that needed to be seen would have been seen on the console already.   But, when capturing output (that is, when running as the serverless plugin), the exit kept the output from being visible.

This change also includes some minor cleanup of the capture logger and other details.  There are fields in the copied-over `CaptureLogger` type that are unused in DO and whose presence is just confusing.   There are also unused arguments in some methods (now marked with an underscore).   I am not removing those right now because it's conceivable (though I think unlikely) that they are used internally to the deployer code.