### PR TITLE
Fix race in runtime agreement calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.11",
+  "version": "5.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digitalocean/functions-deployer",
-      "version": "5.0.11",
+      "version": "5.0.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.11",
+  "version": "5.0.12",
   "description": "The the functions deployer for DigitalOcean",
   "main": "lib/index.js",
   "repository": {

--- a/src/util.ts
+++ b/src/util.ts
@@ -228,16 +228,16 @@ export async function getRuntimeForAction(action: ActionSpec, reader: ProjectRea
 }
 
 // Check whether a list of names that are candidates for zipping can agree on a runtime.  This is called only when the
-// config doesn't already provide a runtime or on the raw material in the case of remote builds.
+// config doesn't already provide a runtime, or on the raw material in the case of remote builds.
 export async function agreeOnRuntime(items: string[]): Promise<string> {
   let agreedRuntime: string
-  items.forEach(async item => {
-    const { runtime } = await actionFileToParts(item)
-    if (runtime) {
-      if (agreedRuntime && runtime !== agreedRuntime) {
+  const partsArray = await Promise.all(items.map(item => actionFileToParts(item)))
+  partsArray.forEach(answer => {
+    if (answer.runtime) {
+      if (agreedRuntime && answer.runtime !== agreedRuntime) {
         return undefined
       }
-      agreedRuntime = runtime
+      agreedRuntime = answer.runtime
     }
   })
   return agreedRuntime


### PR DESCRIPTION
A bug was introduced in trimming down the deployer when the logic for managing runtimes tables was changed.  The `actionFileToParts` function became `async`, requiring an `await` at the call sites.   In introducing this to the `agreeOnRuntime` function, the change failed to consider that the logic was assuming strict sequential execution, but the `await` expressions inside a loop meant that promises would settle in an arbitrary order.   So, the function often gave incorrect results causing spurious deploy failures complaining that the runtime could not be determined.   I switched to a "map reduce" paradigm, with a `Promise.all` in the middle so that the reduce step was again deterministic.