### PR TITLE
Fix project slicing so web: false isn't lost

### DIFF
--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -803,7 +803,7 @@ function makeConfigFromActionSpec(
 // Remove undefined fields from object (mutates object but returns it as well)
 function removeUndefined(obj: Record<string, any>): Record<string, any> {
   for (const item in obj) {
-    if (!obj[item]) {
+    if (typeof obj[item] === 'undefined') {
       delete obj[item];
     } else if (typeof obj[item] === 'object') {
       obj[item] = removeUndefined(obj[item]);


### PR DESCRIPTION
In slicing a project, there is an attempt to remove explicitly undefined fields from the uploaded project.yml to prevent subsequent parsing errors.  This code was erroneously removing all _falsey_ values, including the boolean `false` in `web: false`.

This change fixes that.