### PR TITLE
Minor changes to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11876,8 +11876,7 @@
       }
     },
     "engine.io": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
+      "version": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
       "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
       "dev": true,
       "requires": {
@@ -11894,8 +11893,7 @@
       }
     },
     "engine.io-client": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.3.tgz",
+      "version": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.3.tgz",
       "integrity": "sha512-aXPtgF1JS3RuuKcpSrBtimSjYvrbhKW9froICH4s0F3XQWLxsKNxqzG39nnvQZQnva4CMvUK63T7shevxRyYHw==",
       "dev": true,
       "requires": {
@@ -11918,8 +11916,8 @@
       "integrity": "sha512-Q+V/2W9YV3c3UoOLXHQhEz1cCEb32ewYlLajmBA4r7Epg/MbTnam5RsdGDyVQZNN5+HFbGd5n7ulQkYOtYM5NQ==",
       "dev": true,
       "requires": {
-        "engine.io": "^6.2.1",
-        "engine.io-client": "^6.2.3"
+        "engine.io": "0.7.12",
+        "engine.io-client": "0.7.12"
       }
     },
     "error-ex": {
@@ -14560,7 +14558,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "sockjs": "^0.3.24"
+        "sockjs": "0.3.7"
       },
       "dependencies": {
         "sockjs-client": {
@@ -14599,8 +14597,7 @@
       "dev": true
     },
     "sockjs": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
+      "version": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
       "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
       "dev": true,
       "optional": true,


### PR DESCRIPTION
Recent `npm install` operations on a clean repo clone have mutated `package-lock.json`.   The changes are all in dependencies that are declared in the `overrides` section of `package.json` and I suspect they are a consequence of using open dependencies there.

For now, I am just creating this PR to accept the latest lockfile and move on, granting that this may happen again from time to time.

@ddebarros shall we, instead, simply lock down those dependencies at their current level?  I believe they are all second-order (not of direct interest to us) and are there for defensive purposes following up on vulnerability reports.