### PR TITLE
Support package binding

### DIFF
--- a/e2e/package-binding/.gitignore
+++ b/e2e/package-binding/.gitignore
@@ -1,0 +1,8 @@
+.nimbella
+.deployed
+__deployer__.zip
+__pycache__/
+node_modules
+package-lock.json
+.DS_Store
+packages/

--- a/e2e/package-binding/project.yml
+++ b/e2e/package-binding/project.yml
@@ -1,0 +1,9 @@
+parameters: {}
+environment: {}
+packages:
+    - name: test-package-binding
+      binding:
+        namespace: nimbella
+        name: builder
+      parameters:
+        foo: bar

--- a/e2e/package-binding/test.bats
+++ b/e2e/package-binding/test.bats
@@ -1,0 +1,27 @@
+load ../test_helper.bash
+
+setup_file() {
+  init_namespace
+}
+
+teardown_file() {
+  # This is non-standard because of a controller bug that prevents a GET on a bound package.
+  # DELETE on a bound package works fine but the standard doctl command for deleting a package
+  # always does a GET first to detect the presence of functions in the package.  Here we know there
+  # will be no functions so we can bypass the issue.
+  curl -s -u "$AUTH" -X DELETE "$API_HOST/api/v1/namespaces/_/packages/test-package-binding"   
+}
+
+@test "creating a package binding" {
+  run $DOSLS deploy $BATS_TEST_DIRNAME
+  assert_success
+  # validation
+  # Notes (1) we need to use curl here because doctl sls doesn't have a package list or get.
+  # (2) Getting a bound package explicitly by name appears to be forbidden by the controller, so we
+  # fetch the list of packages and parse it.
+  PKG=$(curl -s -u "$AUTH" "$API_HOST/api/v1/namespaces/_/packages" | jq -r 'map(select(.name=="test-package-binding"))[0]')
+  NAME=$(echo "$PKG" | jq -r .binding.name)
+  NAMESPACE=$(echo "$PKG" | jq -r .binding.namespace)
+  assert_equal "$NAME" builder
+  assert_equal "$NAMESPACE" nimbella
+}

--- a/e2e/package-binding/test.bats
+++ b/e2e/package-binding/test.bats
@@ -12,6 +12,15 @@ teardown_file() {
   curl -s -u "$AUTH" -X DELETE "$API_HOST/api/v1/namespaces/_/packages/test-package-binding"   
 }
 
+@test "error when functions and binding both specified" {
+  mkdir -p $BATS_TEST_DIRNAME/packages/test-package-binding
+  touch $BATS_TEST_DIRNAME/packages/test-package-binding/ringer.js
+  run $DOSLS deploy $BATS_TEST_DIRNAME
+  assert_failure
+  assert_output -p "may not contain functions"
+  rm -fr $BATS_TEST_DIRNAME/packages
+}
+
 @test "creating a package binding" {
   run $DOSLS deploy $BATS_TEST_DIRNAME
   assert_success

--- a/e2e/test_helper.bash
+++ b/e2e/test_helper.bash
@@ -33,6 +33,8 @@ init_namespace() {
   $DOCTL sls connect $TEST_NAMESPACE
 
   CREDS=$($DOCTL sls status --credentials)
+  export API_HOST=$(echo "$CREDS" | jq -r .APIHost)
+  export AUTH=$(echo "$CREDS" | jq -r .Auth)
   export NIMBELLA_DIR=$(echo $CREDS | jq -r .Path)
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -148,6 +148,7 @@ export function deploy(todeploy: DeployStructure): Promise<DeployResponse> {
       if (!results.namespace && todeploy.credentials) {
         results.namespace = todeploy.credentials.namespace;
       }
+      debug('deploy results are: %O', results);
       return results;
     });
 }

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -28,6 +28,13 @@ export interface PackageSpec {
   clean?: boolean; // Indicates that the package is to be deleted (with its contained actions) before deployment
   web?: any; // like 'web' on an action but affects all actions of the package that don't redeclare the flag
   deployedDuringBuild?: boolean; // set when the package was deployed early because some builds were remote
+  binding?: BindingSpec; // may be present in lieu of an actions array if the package is bound to another
+}
+
+// Describes the binding information for a bound package (with no actions of its own)
+export interface BindingSpec {
+  name: string; // the name of the package to which the present package is bound
+  namespace: string; // the namespace of the package to which the present package is bound
 }
 
 // Describes one action
@@ -158,7 +165,7 @@ export interface VersionMap {
   [key: string]: VersionInfo;
 }
 
-export type DeployKind = 'web' | 'action' | 'trigger';
+export type DeployKind = 'web' | 'action' | 'trigger' | 'bound package';
 
 export interface DeploySuccess {
   name: string;

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -165,7 +165,7 @@ export interface VersionMap {
   [key: string]: VersionInfo;
 }
 
-export type DeployKind = 'web' | 'action' | 'trigger' | 'bound package';
+export type DeployKind = 'web' | 'action' | 'trigger' | 'binding';
 
 export interface DeploySuccess {
   name: string;

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -319,7 +319,7 @@ export async function onlyDeployPackage(
         throw new Error('a bound package may not contain functions of its own');
       }
       owPkg.binding = pkg.binding;
-      successes = [{ name: pkg.name, kind: 'bound package', skipped: false }];
+      successes = [{ name: pkg.name, kind: 'binding', skipped: false }];
     }
     debug('successes: %O', successes);
     return await wsk.packages

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -88,7 +88,6 @@ export async function doDeploy(
   const skipPkgDeploy =
     todeploy.slice && todeploy.deployerAnnotation.newSliceHandling;
   delete todeploy.deployerAnnotation.newSliceHandling;
-  debug('there are %d packages', todeploy.packages.length);
   const actionPromises = (todeploy.packages || []).map((pkg) =>
     deployPackage(pkg, todeploy, skipPkgDeploy)
   );

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -316,6 +316,9 @@ export async function onlyDeployPackage(
     };
     let successes: DeploySuccess[] = [];
     if (pkg.binding) {
+      if (pkg.actions && pkg.actions.length > 0) {
+        throw new Error('a bound package may not contain functions of its own');
+      }
       owPkg.binding = pkg.binding;
       successes = [{ name: pkg.name, kind: 'bound package', skipped: false }];
     }

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -90,7 +90,7 @@ export async function buildAllActions(
   const pkgMap = mapPackages(packages);
   const promises: Promise<PackageSpec>[] = [];
   for (const pkg of packages) {
-    if (pkg.actions && pkg.actions.length > 0) {
+    if ((pkg.actions && pkg.actions.length > 0) || pkg.binding) {
       const builtPackage = buildActionsOfPackage(pkg, spec);
       promises.push(builtPackage);
     }
@@ -130,7 +130,7 @@ async function buildActionsOfPackage(
   // Now run all the builds in this package
   const actionMap = mapActions(pkg.actions);
   let nobuilds = true;
-  for (const action of pkg.actions) {
+  for (const action of pkg.actions || []) {
     if (action.build) {
       nobuilds = false;
       const builtAction = await buildAction(action, spec).catch((err) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -456,8 +456,10 @@ function displayResult(
     logger.log('');
     const actions: string[] = [];
     const triggers: string[] = [];
+    const packages: string[] = [];
     let skippedActions = 0;
     let skippedTriggers = 0;
+    let skippedPackages = 0;
     for (const success of result.successes) {
       if (success.kind === 'action') {
         if (success.skipped) {
@@ -471,6 +473,12 @@ function displayResult(
           skippedTriggers++;
         } else {
           triggers.push(success.name);
+        }
+      } else if (success.kind === 'bound package') {
+        if (success.skipped) {
+          skippedPackages++;
+        } else {
+          packages.push(success.name);
         }
       }
     }
@@ -493,6 +501,15 @@ function displayResult(
     }
     if (skippedTriggers > 0) {
       logger.log(`Skipped ${skippedTriggers} triggers`);
+    }
+    if (packages.length > 0) {
+      logger.log('Deployed bound packages:');
+      for (const pkg of packages) {
+        logger.log(`  - ${pkg}`);
+      }
+    }
+    if (skippedPackages > 0) {
+      logger.log(`Skipped ${skippedPackages} bound packages`);
     }
     if (result.failures.length > 0) {
       success = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -474,7 +474,7 @@ function displayResult(
         } else {
           triggers.push(success.name);
         }
-      } else if (success.kind === 'bound package') {
+      } else if (success.kind === 'binding') {
         if (success.skipped) {
           skippedPackages++;
         } else {

--- a/src/util.ts
+++ b/src/util.ts
@@ -458,7 +458,7 @@ async function validatePackageSpec(
   let bindingSeen = false;
   let actionsSeen = false;
   const actionsBindingConflict =
-    'a bound package may not contain actions of its own';
+    'a bound package may not contain functions of its own';
   for (const item in arg) {
     if (!arg[item]) continue;
     if (item === 'name') {
@@ -470,7 +470,7 @@ async function validatePackageSpec(
         return actionsBindingConflict;
       }
       if (!Array.isArray(arg[item])) {
-        return "actions member of a 'package' must be an array";
+        return "functions member of a 'package' must be an array";
       }
       actionsSeen = true;
       for (const subitem of arg[item]) {
@@ -535,7 +535,7 @@ async function validateActionSpec(
       case 'main':
       case 'docker':
         if (!(typeof arg[item] === 'string')) {
-          return `'${item}' member of an 'action' must be a string`;
+          return `'${item}' member of a function must be a string`;
         }
         if (item === 'runtime' && !(await isValidRuntime(arg[item]))) {
           return `'${arg[item]}' is not a valid runtime value`;
@@ -546,7 +546,7 @@ async function validateActionSpec(
       case 'remoteBuild':
       case 'localBuild':
         if (!(typeof arg[item] === 'boolean')) {
-          return `'${item}' member of an 'action' must be a boolean`;
+          return `'${item}' member of a function must be a boolean`;
         }
         break;
       case 'sequence':
@@ -555,12 +555,12 @@ async function validateActionSpec(
           arg[item].length === 0 ||
           typeof arg[item][0] !== 'string'
         ) {
-          return `'${item}' member of an 'action' must be an array of one or more strings naming actions`;
+          return `'${item}' member of a function must be an array of one or more strings naming other functions`;
         }
         break;
       case 'web':
         if (!(typeof arg[item] === 'boolean' || arg[item] === 'raw')) {
-          return `${item} member of an 'action' must be a boolean or the string 'raw'`;
+          return `${item} member of a function must be a boolean or the string 'raw'`;
         }
         break;
       case 'webSecure':
@@ -569,7 +569,7 @@ async function validateActionSpec(
           continue;
         }
         if (!(arg[item] === false || typeof arg[item] === 'string')) {
-          return `'${item}' member of an 'action' must be a boolean false or a string`;
+          return `'${item}' member of a function must be a boolean false or a string`;
         }
         break;
       case 'environment': {

--- a/src/util.ts
+++ b/src/util.ts
@@ -496,7 +496,7 @@ async function validatePackageSpec(
     } else if (item === 'binding') {
       // We don't check here for a package with both actions and a binding because we don't have
       // complete information (just parsing the spec, but the package may have actions in the file system
-      // that aren't in the spec).   This conflict is detected later at deploy time. 
+      // that aren't in the spec).   This conflict is detected later at deploy time.
       if (
         typeof arg[item]?.namespace !== 'string' ||
         typeof arg[item]?.name != 'string'


### PR DESCRIPTION
This change adds support for a `binding` clause under a package entry in `project.yml`.   The effect is to create a bound package.   The `binding` and `functions` (or `actions`) clauses are mutually exclusive.