### PR TITLE
Fix parsing in bootstrap to get the quoting right

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 REAL=$(readlink -f "${BASH_SOURCE[0]}")
 SELF=$(dirname "$REAL")
-"$SELF/node" "$SELF/node_modules/.bin/dosls" $*
+"$SELF/node" "$SELF/node_modules/.bin/dosls" "$@"
+


### PR DESCRIPTION
The `bootstrap` file is used to act as the first catcher of a call to `dosls` in a container where it is installed (runtime container or App Platform container).   Its only job is to pass along the command to the "real" `dosls` while invoking the latter with `node`.   It was failing in that job when arguments were quoted.   This PR provides the trivial fix to that problem.