### PR TITLE
Implement a --no-triggers flag

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -123,7 +123,8 @@ export function readAndPrepare(
     flags.buildEnv,
     includer,
     flags.remoteBuild,
-    feedback
+    feedback,
+    flags.noTriggers
   ).then((spec) =>
     spec.error ? spec : prepareToDeploy(spec, credentials, flags)
   );
@@ -160,7 +161,8 @@ export async function readProject(
   buildEnvPath: string,
   includer: Includer,
   requestRemote: boolean,
-  feedback: Feedback = new DefaultFeedback()
+  feedback: Feedback = new DefaultFeedback(),
+  noTriggers: boolean = false
 ): Promise<DeployStructure> {
   debug(
     'Starting readProject, projectPath=%s, envPath=%s',
@@ -174,7 +176,8 @@ export async function readProject(
       envPath,
       buildEnvPath,
       includer,
-      feedback
+      feedback,
+      noTriggers
     );
     const parts = await buildStructureParts(topLevel);
     ans = assembleInitialStructure(parts);
@@ -206,7 +209,8 @@ export async function readProject(
         envPath,
         buildEnvPath,
         includer,
-        feedback
+        feedback,
+        noTriggers
       );
       const parts = await buildStructureParts(topLevel);
       ans = assembleInitialStructure(parts);

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -105,6 +105,8 @@ export interface Flags {
   auth: string;
   apiHost: string;
   insecure: boolean;
+  // special flag to reject triggers when found in project.yml (for use in contexts where triggers can't be supported)
+  noTriggers: boolean;
 }
 
 // Object to provide feedback (warnings and progress reports) in real time during execution.

--- a/src/main.ts
+++ b/src/main.ts
@@ -179,11 +179,13 @@ const parsing = {
     'yarn',
     'remote-build',
     'incremental',
-    'json'
+    'json',
+    'no-triggers'
   ],
   configuration: {
     'parse-positional-numbers': false,
-    'unknown-options-as-args': true
+    'unknown-options-as-args': true,
+    'boolean-negation': false
   }
 };
 
@@ -221,7 +223,8 @@ export async function runCommand(inputArgs: string[], logger: Logger) {
     yarn,
     remoteBuild,
     incremental,
-    json
+    json,
+    noTriggers
   } = parsed;
   const flags: Flags = {
     env,
@@ -236,7 +239,8 @@ export async function runCommand(inputArgs: string[], logger: Logger) {
     yarn,
     remoteBuild,
     incremental,
-    json
+    json,
+    noTriggers
   };
   switch (cmd) {
     case 'deploy':
@@ -281,10 +285,12 @@ async function doGetMetadata(
     undefined,
     includer,
     false,
-    undefined
+    undefined,
+    flags.noTriggers
   );
   if (result.error && !result.unresolvedVariables) {
-    logger.handleError('  ', result.error);
+    logger.displayError('', result.error);
+    logger.exit(1)
   }
 
   // Fill in any missing runtimes

--- a/src/project-reader.ts
+++ b/src/project-reader.ts
@@ -53,13 +53,15 @@ interface TopLevel {
   includer: Includer;
   reader: ProjectReader;
   feedback: Feedback;
+  noTriggers: boolean;
 }
 export async function readTopLevel(
   filePath: string,
   env: string,
   buildEnv: string,
   includer: Includer,
-  feedback: Feedback
+  feedback: Feedback,
+  noTriggers: boolean
 ): Promise<TopLevel> {
   debug("readTopLevel with filePath:'%s'", filePath);
   debug('feedback is %O', feedback);
@@ -140,7 +142,8 @@ export async function readTopLevel(
       buildEnv,
       includer,
       reader,
-      feedback
+      feedback,
+      noTriggers
     };
     debug('readTopLevel returning %O', ans);
     return ans;
@@ -162,7 +165,8 @@ export async function buildStructureParts(
     buildEnv,
     includer,
     reader,
-    feedback
+    feedback,
+    noTriggers
   } = topLevel;
   let configPart = await readConfig(
     config,
@@ -171,7 +175,8 @@ export async function buildStructureParts(
     filePath,
     includer,
     reader,
-    feedback
+    feedback,
+    noTriggers
   );
   const deployerAnnotation =
     configPart.deployerAnnotation || (await getDeployerAnnotation(filePath));
@@ -472,7 +477,8 @@ async function readConfig(
   filePath: string,
   includer: Includer,
   reader: ProjectReader,
-  feedback: Feedback
+  feedback: Feedback,
+  noTriggers: boolean
 ): Promise<DeployStructure> {
   if (!configFile) {
     debug('No config file found');
@@ -486,7 +492,8 @@ async function readConfig(
     buildEnvPath,
     filePath,
     reader,
-    feedback
+    feedback,
+    noTriggers
   )
     .then((config) => trimConfigWithIncluder(config, includer))
     .catch((err) => errorStructure(err));


### PR DESCRIPTION
This change adds a `--no-triggers` flag to `dosls` main (and to the internal `Flags` type, making it also possible to use in library mode).   It is an optional argument on `readProject`.

The effect of the flag is to make the `triggers` clause in a project illegal instead of simply skipping the deployment of triggers. 