### PR TITLE
Errors should display on stderr not stdout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ export class DefaultLogger implements Logger {
     msg = improveErrorMsg(msg, err);
     verboseError('%O', err);
     const bang = process.platform === 'win32' ? '»' : '›';
-    console.log(bang + '   Error: ' + msg);
+    console.error(bang + '   Error: ' + msg);
   }
 
   exit(code: number): void {


### PR DESCRIPTION
This simply changes the non-terminal error displays in the default logger so that they go to stderr and not stdout.   Terminal errors are thrown and so they already display on stderr.   Many errors in the deployer are output without throwing, and `nim` displayed them on stderr, so this is mostly for backward compatibility.

When using the capture logger (running under `doctl`) the errors are not displayed by the deployer but are ultimately managed by `doctl` so this change will not affect that.  But, I believe `doctl` does display errors on stderr already.