### PR TITLE
Code cleanup

### DIFF
--- a/e2e/remote-build-go/test.bats
+++ b/e2e/remote-build-go/test.bats
@@ -11,10 +11,10 @@ teardown_file() {
 @test "deploy go projects with remote build" {
   run $DOSLS deploy $BATS_TEST_DIRNAME --remote-build --verbose-build
 	assert_success
-	assert_line -p "Submitted action 'test-remote-build-go/default' for remote building and deployment in runtime go:default"
-	assert_line -p "Submitted action 'test-remote-build-go/explicit' for remote building and deployment in runtime go:1.15"
-#	assert_line -p "Submitted action 'test-remote-build-go/dependencies-1.15' for remote building and deployment in runtime go:1.15"
-	assert_line -p "Submitted action 'test-remote-build-go/dependencies-1.17' for remote building and deployment in runtime go:1.17"
+	assert_line -p "Submitted function 'test-remote-build-go/default' for remote building and deployment in runtime go:default"
+	assert_line -p "Submitted function 'test-remote-build-go/explicit' for remote building and deployment in runtime go:1.15"
+#	assert_line -p "Submitted function 'test-remote-build-go/dependencies-1.15' for remote building and deployment in runtime go:1.15"
+	assert_line -p "Submitted function 'test-remote-build-go/dependencies-1.17' for remote building and deployment in runtime go:1.17"
 }
 
 @test "invoke remotely built go lang actions" {

--- a/e2e/remote-build-go1.15/test.bats
+++ b/e2e/remote-build-go1.15/test.bats
@@ -11,7 +11,7 @@ teardown_file() {
 @test "deploy go projects with remote build" {
   run $DOSLS deploy $BATS_TEST_DIRNAME --remote-build --verbose-build
 	assert_success
-	assert_line -p "Submitted action 'test-remote-build-go/dependencies-1.15' for remote building and deployment in runtime go:1.15"
+	assert_line -p "Submitted function 'test-remote-build-go/dependencies-1.15' for remote building and deployment in runtime go:1.15"
 }
 
 @test "invoke remotely built go lang actions" {

--- a/e2e/remote-build-nodejs/test.bats
+++ b/e2e/remote-build-nodejs/test.bats
@@ -11,7 +11,7 @@ teardown_file() {
 @test "deploy nodejs projects with remote build" {
   run $DOSLS deploy $BATS_TEST_DIRNAME --remote-build
 	assert_success
-	assert_line -p "Submitted action 'test-remote-build-nodejs/default' for remote building and deployment in runtime nodejs:default"
+	assert_line -p "Submitted function 'test-remote-build-nodejs/default' for remote building and deployment in runtime nodejs:default"
 }
 
 @test "invoke remotely built nodejs lang actions" {

--- a/e2e/remote-build-php/test.bats
+++ b/e2e/remote-build-php/test.bats
@@ -11,7 +11,7 @@ teardown_file() {
 @test "deploy php projects with remote build" {
   run $DOSLS deploy $BATS_TEST_DIRNAME --remote-build
 	assert_success
-	assert_line -p "Submitted action 'test-remote-build-php/default' for remote building and deployment in runtime php:default"
+	assert_line -p "Submitted function 'test-remote-build-php/default' for remote building and deployment in runtime php:default"
 }
 
 @test "invoke remotely built php lang actions" {

--- a/e2e/remote-build-python/test.bats
+++ b/e2e/remote-build-python/test.bats
@@ -11,7 +11,7 @@ teardown_file() {
 @test "deploy python projects with remote build" {
   run $DOSLS deploy $BATS_TEST_DIRNAME --remote-build
 	assert_success
-	assert_line -p "Submitted action 'test-remote-build-python/default' for remote building and deployment in runtime python:default"
+	assert_line -p "Submitted function 'test-remote-build-python/default' for remote building and deployment in runtime python:default"
 }
 
 @test "invoke remotely built python lang actions" {

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,7 @@
 
 // Contains the main public (library) API of the deployer (some exports in 'util' may also be used externally but are incidental)
 
-import { cleanOrLoadVersions, doDeploy, cleanPackage } from './deploy';
+import { doDeploy, maybeLoadVersions } from './deploy';
 import {
   DeployStructure,
   DeployResponse,
@@ -133,7 +133,7 @@ export function readAndPrepare(
 // Perform deployment from a deploy structure.  The 'cleanOrLoadVersions' step is currently folded into this step
 export function deploy(todeploy: DeployStructure): Promise<DeployResponse> {
   debug('Starting deploy');
-  return cleanOrLoadVersions(todeploy)
+  return maybeLoadVersions(todeploy)
     .then(doDeploy)
     .then((results) => {
       const statusDir = writeProjectStatus(
@@ -344,22 +344,4 @@ export async function wipeNamespace(credentials: Credentials): Promise<void> {
   const client = openwhisk(init);
   debug('Client opened');
   return wipe(client, credentials);
-}
-
-// Completely remove a package including its contained actions
-export async function wipePackage(
-  name: string,
-  host: string,
-  auth: string,
-  credentials: Credentials
-): Promise<openwhisk.Package> {
-  debug(
-    "wipePackage invoked with name='%s', host='%s', auth='%s",
-    name,
-    host,
-    auth
-  );
-  const init: OWOptions = { apihost: host, api_key: auth };
-  const client = openwhisk(init);
-  return cleanPackage(client, credentials, name, undefined);
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -191,32 +191,10 @@ export async function readProject(
     return ans;
   }
   debug('evaluating the just-read project: %O', ans);
-  let needsLocalBuilds: boolean;
   try {
-    needsLocalBuilds = await checkBuildingRequirements(ans, requestRemote);
-    debug('needsLocalBuilds=%s', needsLocalBuilds);
+    await checkBuildingRequirements(ans, requestRemote);
   } catch (err) {
     return errorStructure(err);
-  }
-  if (needsLocalBuilds && ans.reader.getFSLocation() === null) {
-    debug(
-      "project '%s' will be re-read and cached because it is covered by a non-file-system reader and needs local building",
-      projectPath
-    );
-    try {
-      const topLevel = await readTopLevel(
-        projectPath,
-        envPath,
-        buildEnvPath,
-        includer,
-        feedback,
-        noTriggers
-      );
-      const parts = await buildStructureParts(topLevel);
-      ans = assembleInitialStructure(parts);
-    } catch (err) {
-      return errorStructure(err);
-    }
   }
   return ans;
 }

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -25,7 +25,6 @@ export interface PackageSpec {
   annotations?: Dict; // package annotations
   parameters?: Dict; // Bound parameters for all actions in the package, passed in the usual way
   environment?: Dict; // Bound parameters for all actions in the package, destined to go in the environment of each action
-  clean?: boolean; // Indicates that the package is to be deleted (with its contained actions) before deployment
   web?: any; // like 'web' on an action but affects all actions of the package that don't redeclare the flag
   deployedDuringBuild?: boolean; // set when the package was deployed early because some builds were remote
   binding?: BindingSpec; // may be present in lieu of an actions array if the package is bound to another
@@ -58,7 +57,6 @@ export interface ActionSpec {
   parameters?: Dict; // Bound parameters for the action passed in the usual way
   environment?: Dict; // Bound parameters for the action destined to go in the environment
   limits?: Limits; // Action limits (time, memory, logs)
-  clean?: boolean; // Indicates that an old copy of the action should be removed before deployment
   remoteBuild?: boolean; // States that the build (if any) must be done remotely
   localBuild?: boolean; // States that the build (if any) must be done locally
   triggers?: TriggerSpec[]; // Triggers for the function if any
@@ -134,7 +132,6 @@ export class DefaultFeedback implements Feedback {
 export interface DeployStructure {
   packages?: PackageSpec[]; // The packages found in the package directory
   targetNamespace?: string; // The namespace to which we are deploying
-  cleanNamespace?: boolean; // Clears entire namespace prior to deploying
   parameters?: Dict; // Parameters to apply to all packages in the project
   environment?: Dict; // Environment to apply to all packages in the project
   // The following fields are not documented for inclusion project.yml but may be present in a project slice config (remote build)

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -149,7 +149,7 @@ export interface DeployStructure {
   strays?: string[]; // files or directories found in the project that don't fit the model, not necessarily an error
   filePath?: string; // The location of the project on disk
   owClient?: Client; // The openwhisk client for deploying actions and packages
-  includer?: Includer; // The 'includer' for deciding which packages, actions, web are included in the deploy
+  includer?: Includer; // The 'includer' for deciding which packages and actions are included in the deploy
   reader?: ProjectReader; // The project reader to use
   versions?: VersionEntry; // The VersionEntry for credentials.namespace on the selected API host if available
   feedback?: Feedback; // The object to use for immediate communication to the user (e.g. for warnings and progress reports)
@@ -167,7 +167,7 @@ export interface VersionMap {
   [key: string]: VersionInfo;
 }
 
-export type DeployKind = 'web' | 'action' | 'trigger' | 'binding';
+export type DeployKind = 'action' | 'trigger' | 'binding';
 
 export interface DeploySuccess {
   name: string;
@@ -184,7 +184,6 @@ export interface DeployResponse {
   packageVersions: VersionMap;
   actionVersions: VersionMap;
   apihost?: string;
-  webHashes?: { [key: string]: string };
 }
 
 // The version file entry for a given deployment
@@ -193,7 +192,6 @@ export interface VersionEntry {
   namespace: string;
   packageVersions: VersionMap;
   actionVersions: VersionMap;
-  webHashes: { [key: string]: string };
 }
 
 // The annotation placed in every action and package deployed by the deployer
@@ -275,7 +273,7 @@ export interface CredentialRow {
   apihost: string;
 }
 
-// The Includer object is used during project reading and deployment to screen web, packages, and actions to be included
+// The Includer object is used during project reading and deployment to screen packages, and actions to be included
 export interface Includer {
   isPackageIncluded: (pkg: string, all: boolean) => boolean;
   isActionIncluded: (pkg: string, action: string) => boolean;

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -53,7 +53,7 @@ type Exec = openwhisk.Exec & { image?: string };
 // Main deploy logic, excluding that assigned to more specialized files
 //
 
-// The max number of operations to have outstanding at a time (for actions and web resources).
+// The max number of operations to have outstanding at a time (for actions).
 // It isn't obvious how to tune this, but 25 seems to work reliably and 50 sometimes has
 // failures.  I have had success with 40, actually, but don't want to push our luck.
 const DEPLOYMENT_CHUNK_SIZE = parseInt(process.env.DEPLOYMENT_CHUNK_SIZE) || 25;

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -16,11 +16,9 @@ import {
   DeployResponse,
   ActionSpec,
   PackageSpec,
-  VersionEntry,
   KeyVal,
   Feedback,
-  DeploySuccess,
-  Credentials
+  DeploySuccess
 } from './deploy-struct';
 import {
   combineResponses,
@@ -30,13 +28,11 @@ import {
   emptyResponse,
   getActionName,
   straysToResponse,
-  wipe,
   makeDict,
   digestPackage,
   digestAction,
   loadVersions,
-  waitForActivation,
-  deleteAction
+  waitForActivation
 } from './util';
 import openwhisk from 'openwhisk';
 import { deployTriggers } from './triggers';
@@ -58,10 +54,8 @@ type Exec = openwhisk.Exec & { image?: string };
 // failures.  I have had success with 40, actually, but don't want to push our luck.
 const DEPLOYMENT_CHUNK_SIZE = parseInt(process.env.DEPLOYMENT_CHUNK_SIZE) || 25;
 
-// Clean resources as requested unless the 'incremental', 'include' or 'exclude' is specified.
-// For 'incremental', cleaning is skipped entirely.  Otherwise, cleaning is skipped for portions of
-// the project not included in the deployment.  Note: there should always be an Includer by the time we reach here.
-export async function cleanOrLoadVersions(
+// Load the versions if incremental.  If not incremental, the former versions are irrelevant.
+export async function maybeLoadVersions(
   todeploy: DeployStructure
 ): Promise<DeployStructure> {
   if (todeploy.flags.incremental) {
@@ -71,17 +65,11 @@ export async function cleanOrLoadVersions(
       todeploy.credentials.namespace,
       todeploy.credentials.ow.apihost
     );
-  } else {
-    if (todeploy.cleanNamespace && todeploy.includer.isIncludingEverything()) {
-      await wipe(todeploy.owClient, todeploy.credentials);
-    } else {
-      await cleanActionsAndPackages(todeploy);
-    }
   }
   return Promise.resolve(todeploy);
 }
 
-// Do the actual deployment (after testing the target namespace and cleaning)
+// Do the actual deployment
 export async function doDeploy(
   todeploy: DeployStructure
 ): Promise<DeployResponse> {
@@ -151,92 +139,11 @@ async function processRemoteResponse(
   return outcome;
 }
 
-// Look for 'clean' flags in the actions and packages and perform the cleaning.
-function cleanActionsAndPackages(
-  todeploy: DeployStructure
-): Promise<DeployStructure> {
-  if (!todeploy.packages) {
-    return Promise.resolve(todeploy);
-  }
-  const promises: Promise<any>[] = [];
-  for (const pkg of todeploy.packages) {
-    const defaultPkg = pkg.name === 'default';
-    if (
-      pkg.clean &&
-      !defaultPkg &&
-      todeploy.includer.isPackageIncluded(pkg.name, true)
-    ) {
-      // We should have headed off 'clean' of the default package already.  The added test is just in case
-      promises.push(
-        cleanPackage(
-          todeploy.owClient,
-          todeploy.credentials,
-          pkg.name,
-          todeploy.versions
-        )
-      );
-    } else if (pkg.actions) {
-      for (const action of pkg.actions) {
-        if (
-          action.clean &&
-          todeploy.includer.isActionIncluded(pkg.name, action.name) &&
-          !action.buildResult
-        ) {
-          if (todeploy.versions && todeploy.versions.actionVersions) {
-            delete todeploy.versions.actionVersions[action.name];
-          }
-          promises.push(
-            deleteAction(
-              getActionName(action),
-              todeploy.owClient,
-              todeploy.credentials
-            ).catch(() => undefined)
-          );
-        }
-      }
-    }
-  }
-  return Promise.all(promises).then(() => todeploy);
-}
-
-// Clean a package by first deleting its contents then deleting the package itself
-// The 'versions' argument can be undefined, allowing this to be used to delete packages without a project context
-export async function cleanPackage(
-  client: openwhisk.Client,
-  credentials: Credentials,
-  name: string,
-  versions: VersionEntry
-): Promise<openwhisk.Package> {
-  debug('Cleaning package %s', name);
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const pkg = await client.packages.get({ name }).catch(() => undefined);
-    if (!pkg) {
-      return { name };
-    }
-    if (!pkg.actions || pkg.actions.length === 0) {
-      debug('No more actions, removing package');
-      if (versions && versions.packageVersions) {
-        delete versions.packageVersions[name];
-      }
-      return client.packages.delete({ name });
-    }
-    for (const action of pkg.actions) {
-      debug('deleting action %s', action.name);
-      if (versions && versions.actionVersions) {
-        delete versions.actionVersions[action.name];
-      }
-      await deleteAction(name + '/' + action.name, client, credentials);
-    }
-  }
-}
-
 // Deploy an array of actions of arbitrary size, ensuring that most CHUNK_SIZE operations
 // are pending at the same time.
 async function deployActionArray(
   actions: ActionSpec[],
-  spec: DeployStructure,
-  cleanFlag: boolean
+  spec: DeployStructure
 ): Promise<DeployResponse> {
   let pending = actions;
   const responses: DeployResponse[] = [];
@@ -247,7 +154,7 @@ async function deployActionArray(
         : pending;
     pending = pending.slice(chunk.length);
     const chunkResults = await Promise.all(
-      chunk.map((action) => deployAction(action, spec, cleanFlag))
+      chunk.map((action) => deployAction(action, spec))
     ).then(combineResponses);
     responses.push(chunkResults);
     chunkDebug('Deployed chunk of %d actions', chunk.length);
@@ -265,7 +172,6 @@ export async function onlyDeployPackage(
   const {
     parameters: projectParams,
     environment: projectEnv,
-    cleanNamespace: namespaceIsClean,
     versions,
     owClient: wsk,
     deployerAnnotation: deployer,
@@ -291,12 +197,9 @@ export async function onlyDeployPackage(
       namespace: undefined
     };
   } else {
-    let former: openwhisk.Package;
-    if (!pkg.clean && !namespaceIsClean) {
-      former = await wsk.packages
-        .get({ name: pkg.name })
-        .catch(() => undefined);
-    }
+    const former = await wsk.packages
+      .get({ name: pkg.name })
+      .catch(() => undefined);
     const oldAnnots =
       former && former.annotations ? makeDict(former.annotations) : {};
     delete oldAnnots.deployerAnnot; // remove unwanted legacy from undetected earlier error
@@ -342,17 +245,13 @@ export async function onlyDeployPackage(
   }
 }
 
-// Deploy a package, then deploy everything in it (currently just actions).
+// Deploy a package, then deploy everything in it (currently just actions and triggers associated with those actions).
 export async function deployPackage(
   pkg: PackageSpec,
   spec: DeployStructure,
   skipPkgDeploy: boolean
 ): Promise<DeployResponse> {
-  const {
-    parameters: projectParams,
-    environment: projectEnv,
-    cleanNamespace: namespaceIsClean
-  } = spec;
+  const { parameters: projectParams, environment: projectEnv } = spec;
   if (
     pkg.name === 'default' &&
     (pkg.binding ||
@@ -372,15 +271,11 @@ export async function deployPackage(
     );
   }
   if (pkg.name === 'default' || skipPkgDeploy || pkg.deployedDuringBuild) {
-    return deployActionArray(pkg.actions, spec, namespaceIsClean);
+    return deployActionArray(pkg.actions, spec);
   }
   const pkgResponse = await onlyDeployPackage(pkg, spec);
   // Now deploy (or skip) the actions of the package
-  const actionPromise = await deployActionArray(
-    pkg.actions || [],
-    spec,
-    pkg.clean || namespaceIsClean
-  );
+  const actionPromise = await deployActionArray(pkg.actions || [], spec);
   return combineResponses([actionPromise, pkgResponse]);
 }
 
@@ -398,8 +293,7 @@ function isAtLeastOneNonEmpty(toCheck: object[]): boolean {
 // Deploy an action
 function deployAction(
   action: ActionSpec,
-  spec: DeployStructure,
-  pkgIsClean: boolean
+  spec: DeployStructure
 ): Promise<DeployResponse> {
   const { owClient: wsk, feedback, reader } = spec;
   const context = `action '${getActionName(action)}'`;
@@ -412,13 +306,7 @@ function deployAction(
   }
   if (action.code) {
     debug('action already has code');
-    return deployActionFromCodeOrSequence(
-      action,
-      spec,
-      action.code,
-      undefined,
-      pkgIsClean
-    );
+    return deployActionFromCodeOrSequence(action, spec, action.code, undefined);
   }
   if (action.sequence) {
     const error = checkForLegalSequence(action);
@@ -441,13 +329,7 @@ function deployAction(
         return code;
       })
       .then((code: string) =>
-        deployActionFromCodeOrSequence(
-          action,
-          spec,
-          code,
-          undefined,
-          pkgIsClean
-        )
+        deployActionFromCodeOrSequence(action, spec, code, undefined)
       )
       .catch((err) => Promise.resolve(wrapError(err, context)));
   } else {
@@ -591,26 +473,10 @@ async function deploySequences(
     );
     const exec: openwhisk.Sequence = { kind: 'sequence', components };
     result.push(
-      await deployActionFromCodeOrSequence(
-        seq,
-        todeploy,
-        undefined,
-        exec,
-        isCleanPkg(todeploy, seq.package)
-      )
+      await deployActionFromCodeOrSequence(seq, todeploy, undefined, exec)
     );
   }
   return result;
-}
-
-// Lookup a package in the DeployStructure and answer whether it is cleaned.  If the spec is cleaning
-// the namespace that counts and we return true.
-function isCleanPkg(spec: DeployStructure, pkgName: string): boolean {
-  if (spec.cleanNamespace) {
-    return true;
-  }
-  const pkg = (spec.packages || []).find((pkg) => pkg.name === pkgName);
-  return !!pkg?.clean;
 }
 
 // Compute a fully qualified OW name from an ActionSpec plus a default namespace
@@ -686,8 +552,7 @@ async function deployActionFromCodeOrSequence(
   action: ActionSpec,
   spec: DeployStructure,
   code: string,
-  sequence: openwhisk.Sequence,
-  pkgIsClean: boolean
+  sequence: openwhisk.Sequence
 ): Promise<DeployResponse> {
   const name = getActionName(action);
   const { versions, flags, deployerAnnotation, owClient: wsk } = spec;
@@ -754,11 +619,8 @@ async function deployActionFromCodeOrSequence(
     annotations['require-whisk-auth'] = false;
   }
   // Get the former annotations of the action if any
-  let former: openwhisk.Action;
-  if (!action.clean && !pkgIsClean) {
-    const options = { name, code: false };
-    former = await wsk.actions.get(options).catch(() => undefined);
-  }
+  const options = { name, code: false };
+  const former = await wsk.actions.get(options).catch(() => undefined);
   const oldAnnots =
     former && former.annotations ? makeDict(former.annotations) : {};
   // Merge the annotations

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -73,7 +73,7 @@ export function getBuildForAction(
   reader: ProjectReader
 ): Promise<string> {
   return readDirectory(filepath, reader).then((items) =>
-    findSpecialFile(items, filepath, true, false)
+    findSpecialFile(items, filepath, true)
   );
 }
 
@@ -418,17 +418,16 @@ function readFileAsList(
   );
 }
 
-// Determine the build step for the lib or web directory or return undefined if there isn't one
-export function getBuildForLibOrWeb(
+// Determine the build step for the lib directory or return undefined if there isn't one
+export function getBuildForLib(
   filepath: string,
-  reader: ProjectReader,
-  lib: boolean
+  reader: ProjectReader
 ): Promise<string> {
   if (!filepath) {
     return Promise.resolve(undefined);
   }
   return readDirectory(filepath, reader).then((items) =>
-    findSpecialFile(items, filepath, false, lib)
+    findSpecialFile(items, filepath, false)
   );
 }
 
@@ -1004,7 +1003,7 @@ function readDirectory(
   return reader.readdir(filepath).then(filterFiles);
 }
 
-// Find the "dominant" special file in a collection of files within an action, web, or lib directory, while checking for some errors
+// Find the "dominant" special file in a collection of files within an action or lib directory, while checking for some errors
 // The dominance order is build.[sh|cmd] > .build > package.json > .include > none-of-these (returns 'identify' since 'building' will
 //   then start by identifying files)
 // Errors detected are:
@@ -1017,8 +1016,7 @@ function readDirectory(
 function findSpecialFile(
   items: PathKind[],
   filepath: string,
-  isAction: boolean,
-  isLib: boolean
+  isAction: boolean
 ): string {
   const files = items.filter((item) => !item.isDirectory);
   let buildDotSh = false;
@@ -1049,7 +1047,7 @@ function findSpecialFile(
     (files.length === 0 || (ignore && files.length === 1))
   ) {
     throw new Error(`Action directory ${filepath} has no files`);
-  } else if (isLib && (include || ignore)) {
+  } else if (!isAction && (include || ignore)) {
     throw new Error(
       `'.include' and '.ignore' are not supported in the 'lib' directory`
     );

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -735,7 +735,6 @@ function makeConfigFromActionSpec(
   debug('converting action spec to sliced project.yml: %O', action);
   const {
     targetNamespace,
-    cleanNamespace,
     parameters,
     environment: globalEnv,
     credentials,
@@ -755,12 +754,10 @@ function makeConfigFromActionSpec(
     webSecure,
     annotations,
     environment,
-    limits,
-    clean
+    limits
   } = action;
   const newSpec = {
     targetNamespace,
-    cleanNamespace,
     parameters,
     environment: globalEnv,
     credentials,
@@ -780,8 +777,7 @@ function makeConfigFromActionSpec(
     annotations,
     parameters: action.parameters,
     environment,
-    limits,
-    clean
+    limits
   } as ActionSpec;
   removeUndefined(newSpec);
   removeUndefined(newAction);

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -243,12 +243,11 @@ function buildAction(
 async function processInclude(
   includesPath: string,
   dirPath: string,
-  reader: ProjectReader,
-  web: boolean
+  reader: ProjectReader
 ): Promise<string[][]> {
   debug("processing includes from '%s'", includesPath);
   const items = await readFileAsList(includesPath, reader);
-  const errMsg = checkIncludeItems(items, web);
+  const errMsg = checkIncludeItems(items);
   if (errMsg) {
     return Promise.reject(new Error(errMsg));
   }
@@ -340,24 +339,22 @@ async function identifyActionFiles(
   }
   if (await reader.isExistingFile(includesPath)) {
     // If there is .include or .source, it is canonical and all else is ignored
-    return processInclude(includesPath, action.file, reader, false).then(
-      (pairs) => {
-        if (pairs.length === 0) {
-          return Promise.reject(new Error(includesPath + ' is empty'));
-        } else if (pairs.length > 1) {
-          return autozipBuilder(
-            pairs,
-            action,
-            incremental,
-            verboseZip,
-            reader,
-            feedback
-          );
-        } else {
-          return singleFileBuilder(action, pairs[0][0]);
-        }
+    return processInclude(includesPath, action.file, reader).then((pairs) => {
+      if (pairs.length === 0) {
+        return Promise.reject(new Error(includesPath + ' is empty'));
+      } else if (pairs.length > 1) {
+        return autozipBuilder(
+          pairs,
+          action,
+          incremental,
+          verboseZip,
+          reader,
+          feedback
+        );
+      } else {
+        return singleFileBuilder(action, pairs[0][0]);
       }
-    );
+    });
   }
   return getIgnores(action.file, reader).then((ignore) => {
     return promiseFilesAndFilterFiles(action.file, reader).then(
@@ -529,8 +526,8 @@ function checkBuiltLocally(reader: ProjectReader, localPath: string) {
 
 // Check that all include file items resolve to "legal" places (inside the directory being built or a 'lib' directory at project root)
 // Returns an error message if an illegal item is found, else the empty string.
-export function checkIncludeItems(items: string[], web: boolean): string {
-  const legalDots = web ? '../lib' : '../../../lib';
+export function checkIncludeItems(items: string[]): string {
+  const legalDots = '../../../lib';
   for (const item of items) {
     if (!item || item.length === 0) {
       continue;
@@ -549,8 +546,7 @@ export function checkIncludeItems(items: string[], web: boolean): string {
 // a "fail-fast" for remote builds that are going to fail anyway.
 async function checkRemoteBuildPreReqs(
   filepath: string,
-  project: DeployStructure,
-  web: boolean
+  project: DeployStructure
 ) {
   debug(`checking remote build pre-reqs for '${filepath}'`);
   const reader = project.reader;
@@ -560,7 +556,7 @@ async function checkRemoteBuildPreReqs(
       debug(`found an .include file for '${filepath}'`);
       const items = await readFileAsList(include, reader);
       debug(`read ${items.length} .include items for '${filepath}'`);
-      const msg = checkIncludeItems(items, web);
+      const msg = checkIncludeItems(items);
       if (msg) {
         throw new Error(msg);
       }
@@ -574,7 +570,7 @@ async function doRemoteActionBuild(
   project: DeployStructure
 ): Promise<ActionSpec> {
   // Check that a remote build is supportable
-  await checkRemoteBuildPreReqs(action.file, project, false);
+  await checkRemoteBuildPreReqs(action.file, project);
   // Get the zipper
   const { zip, output, outputPromise } = makeProjectSliceZip(action.file);
   // Get the project slice in convenient form
@@ -652,8 +648,8 @@ function defaultRemote(action: ActionSpec): DefaultRemoteBuildInfo {
   return undefined;
 }
 
-// Zip a file or directory for a remote build slice.  For actions, also attempts to determine a runtime.
-// For web builds, the returned 'runtime' is irrelevant and can be ignored.  If the generateBuild argument
+// Zip a file or directory for a remote build slice.  Also attempts to determine a runtime.
+// If the generateBuild argument
 // is defined, it provides the action directory name and indicates that we should add a two-line `build.sh`.
 // This may require changing the single-file case to a multi-file case.
 async function appendToZip(
@@ -729,7 +725,7 @@ async function appendAndCheck(
   zipDebug("zipped '%s' for remote build slice", file);
 }
 
-// Slice the project to contain only one ActionSpec and no web folder; return a DeployStructure that can be written
+// Slice the project to contain only one ActionSpec; return a DeployStructure that can be written
 // out as a project.yml and also the path to the action file or directory, for zipping.
 function makeConfigFromActionSpec(
   action: ActionSpec,
@@ -866,12 +862,8 @@ export function getRemoteBuildName(): string {
 }
 
 // Computes the tag to be added to a remote build slice name.  Should be a function of the
-// qualified action name (pkg/action) but with / replaced by _.  Also, if there is no
-// action spec we assume this is a remote web build and use the string 'web'
+// qualified action name (pkg/action) but with / replaced by _.
 function computeTag(action: ActionSpec): string {
-  if (!action) {
-    return 'web';
-  }
   if (action.package) {
     return `${action.package}_${action.name}`;
   }
@@ -931,12 +923,12 @@ async function getUploadUrl(
   return { url: result.url, sliceName: result.sliceName };
 }
 
-// Invoke the remote builder, return the response.  The 'action' argument is omitted for web builds
+// Invoke the remote builder, return the response.
 async function invokeRemoteBuilder(
   zipped: Buffer,
   owClient: openwhisk.Client,
   feedback: Feedback,
-  action?: ActionSpec,
+  action: ActionSpec,
   encryptionKey?: string
 ): Promise<string> {
   // Upload project slice
@@ -961,11 +953,9 @@ async function invokeRemoteBuilder(
   }
   debug('axios put of url was successful');
   // Invoke the remote builder action.  The action name incorporates the runtime 'kind'.
-  // That action will re-invoke the nim deployer in the target runtime.
-  const kind = action ? action.runtime : 'nodejs:default';
-  const activityName = action
-    ? `action '${getActionName(action)}'`
-    : 'web content';
+  // That action will re-invoke the deployer in the target runtime.
+  const kind = action.runtime;
+  const activityName = `function '${getActionName(action)}'`;
   const runtime = (await canonicalRuntime(kind)).replace(':', '_');
   const buildActionName = `${BUILDER_ACTION_STEM}${runtime}`;
   debug(
@@ -1011,7 +1001,7 @@ function readDirectory(
 //    build.sh but no build.cmd on a windows system
 //    build.cmd but no build.sh on a macos or linux system
 //    .ignore when there is also .include
-//    no files in directory (or only an .ignore file); actions only (web directory is permitted to be empty)
+//    no files in directory (or only an .ignore file); actions only
 //    in a 'lib' directory .include, .ignore, and .build are illegal
 function findSpecialFile(
   items: PathKind[],
@@ -1054,6 +1044,8 @@ function findSpecialFile(
   }
   if (process.platform === 'win32') {
     if (buildDotSh && !buildDotCmd) {
+      // TODO this is erroneous here (issue #39).  It is not known here whether the build is
+      // local or remote.  So, the test for this error should be delayed into the build phase.
       throw new Error(
         `In ${filepath}: 'build.sh' won't run on this platform and no 'build.cmd' is provided`
       );
@@ -1064,6 +1056,8 @@ function findSpecialFile(
   } else {
     // mac or linux
     if (!buildDotSh && buildDotCmd) {
+      // TODO This is ok here because it is an error regardless of whether the build is local or remote.
+      // But probably if the dual test is delayed to a later phase, this should be as well.
       throw new Error(
         `In ${filepath}: 'build.cmd' won't run on this platform and no 'build.sh' is provided`
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,6 @@ export {
   buildProject,
   prepareToDeploy,
   wipeNamespace,
-  wipePackage,
   getUserAgent
 } from './api';
 export {

--- a/src/project-reader.ts
+++ b/src/project-reader.ts
@@ -31,7 +31,7 @@ import {
   getDeployerAnnotation,
   getBestProjectName
 } from './util';
-import { getBuildForAction, getBuildForLibOrWeb } from './finder-builder';
+import { getBuildForAction, getBuildForLib } from './finder-builder';
 import makeDebug from 'debug';
 import { makeFileReader } from './file-reader';
 import { fetchSlice } from './slice-reader';
@@ -196,7 +196,7 @@ export async function buildStructureParts(
     includer,
     reader
   );
-  configPart.libBuild = await getBuildForLibOrWeb(lib, reader, true);
+  configPart.libBuild = await getBuildForLib(lib, reader);
   return [actionsPart, configPart];
 }
 

--- a/src/project-reader.ts
+++ b/src/project-reader.ts
@@ -201,8 +201,7 @@ export async function buildStructureParts(
 }
 
 // Assemble a complete initial structure containing all file system information and config.  May be deployed as is or adjusted
-// before deployment.  Input is the resolved output of buildStructureParts.  At this point, the web part may have names that
-// are only suitable for bucket deploy so we check for that problem here.
+// before deployment.  Input is the resolved output of buildStructureParts.
 export function assembleInitialStructure(
   parts: DeployStructure[]
 ): DeployStructure {
@@ -342,7 +341,7 @@ function buildActionsPart(
       reader
     ).then((values) => {
       const [strays, pkgs] = values;
-      return { web: [], packages: pkgs, strays: strays };
+      return { packages: pkgs, strays: strays };
     });
   }
 }
@@ -501,7 +500,7 @@ async function readConfig(
   return config;
 }
 
-// Given a DeployStructure with web and package sections, trim those sections according to the rules of an Includer
+// Given a DeployStructure with a package section, trim that section according to the rules of an Includer
 function trimConfigWithIncluder(
   config: DeployStructure,
   includer: Includer

--- a/src/util.ts
+++ b/src/util.ts
@@ -850,10 +850,6 @@ export function combineResponses(responses: DeployResponse[]): DeployResponse {
     (prev, curr) => Object.assign(prev, curr.actionVersions),
     {}
   );
-  const webHashes = responses.reduce(
-    (prev, curr) => Object.assign(prev, curr.webHashes || {}),
-    {}
-  );
   const namespace = responses
     .map((r) => r.namespace)
     .reduce((prev, curr) => prev || curr);
@@ -863,7 +859,6 @@ export function combineResponses(responses: DeployResponse[]): DeployResponse {
     ignored,
     packageVersions,
     actionVersions,
-    webHashes,
     namespace
   };
 }
@@ -1581,12 +1576,10 @@ export function writeProjectStatus(
   replace: boolean
 ): string {
   debug('writing project status with %O', results);
-  const { apihost, namespace, packageVersions, actionVersions, webHashes } =
-    results;
+  const { apihost, namespace, packageVersions, actionVersions } = results;
   if (
     Object.keys(actionVersions).length === 0 &&
-    Object.keys(packageVersions).length === 0 &&
-    Object.keys(webHashes).length === 0
+    Object.keys(packageVersions).length === 0
   ) {
     debug('there is no meaningful project status to write');
     return '';
@@ -1606,8 +1599,7 @@ export function writeProjectStatus(
     apihost,
     namespace,
     packageVersions,
-    actionVersions,
-    webHashes
+    actionVersions
   };
   const oldEntry: VersionEntry = versionList.find(
     (entry) => entry.apihost === apihost && entry.namespace === namespace
@@ -1625,7 +1617,7 @@ export function writeProjectStatus(
 }
 
 // Merge new information into old information within the version store.
-// If replace is specified, each major element of the old entry (packageVersions, actionVersions, webHashes) is replaced
+// If replace is specified, each major element of the old entry (packageVersions, actionVersions) is replaced
 // with the new.  Otherwise, the dictionaries are merged.
 function mergeVersions(
   oldEntry: VersionEntry,
@@ -1637,7 +1629,6 @@ function mergeVersions(
   } else {
     Object.assign(oldEntry.actionVersions, newEntry.actionVersions);
     Object.assign(oldEntry.packageVersions, newEntry.packageVersions);
-    Object.assign(oldEntry.webHashes, newEntry.webHashes);
   }
 }
 
@@ -1660,8 +1651,7 @@ export function loadVersions(
     namespace,
     apihost,
     packageVersions: {},
-    actionVersions: {},
-    webHashes: {}
+    actionVersions: {}
   };
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -237,17 +237,13 @@ function locateBuild(
   return buildField;
 }
 
-// Set up the build fields for a project and detect conflicts.  Determine if local building is required.
+// Set up the build fields for a project and detect conflicts.
+// Returns true if any build is required to be local.
 export async function checkBuildingRequirements(
   todeploy: DeployStructure,
   requestRemote: boolean
 ): Promise<boolean> {
-  const checkConflicts = (
-    buildField: string,
-    remote: boolean,
-    local: boolean,
-    tag: string
-  ) => {
+  const checkConflicts = (remote: boolean, local: boolean, tag: string) => {
     if (remote && local) {
       throw new Error(
         `Local and remote building cannot both be required (${tag})`
@@ -259,10 +255,9 @@ export async function checkBuildingRequirements(
       if (pkg.actions) {
         for (const action of pkg.actions) {
           checkConflicts(
-            action.build,
             action.remoteBuild,
             action.localBuild,
-            `action ${action.name}`
+            `function ${action.name}`
           );
         }
       }

--- a/src/util.ts
+++ b/src/util.ts
@@ -386,10 +386,6 @@ export async function validateDeployConfig(
     switch (item) {
       case 'slice':
         continue;
-      case 'cleanNamespace':
-        if (!(typeof arg[item] === 'boolean')) {
-          return `${item} must be a boolean`;
-        }
         break;
       case 'targetNamespace': {
         if (!(typeof arg[item] === 'string') && !isValidOwnership(arg[item])) {
@@ -476,7 +472,7 @@ async function validatePackageSpec(
           return actionError;
         }
       }
-    } else if (item === 'shared' || item === 'clean') {
+    } else if (item === 'shared') {
       if (!(typeof arg[item] === 'boolean')) {
         return `'${item}' member of a 'package' must be a boolean`;
       } else if (isDefault && arg[item]) {
@@ -539,7 +535,6 @@ async function validateActionSpec(
         }
         break;
       case 'binary':
-      case 'clean':
       case 'remoteBuild':
       case 'localBuild':
         if (!(typeof arg[item] === 'boolean')) {
@@ -1471,7 +1466,6 @@ function isProductionProject(
 export function digestPackage(pkg: PackageSpec): string {
   const hash = crypto.createHash('sha256');
   digestBoolean(hash, pkg.shared);
-  digestBoolean(hash, pkg.clean);
   digestBoolean(hash, pkg.web);
   digestDictionary(hash, pkg.annotations);
   digestDictionary(hash, pkg.parameters);
@@ -1522,7 +1516,6 @@ function digestDictionary(hash: crypto.Hash, toDigest: Record<string, any>) {
 // Compute the digest of an ActionSpec.  Code is provided as a separate argument (code member of the ActionSpec will either be identical or undefined)
 export function digestAction(action: ActionSpec, code: string): string {
   const hash = crypto.createHash('sha256');
-  digestBoolean(hash, action.clean);
   digestBoolean(hash, action.binary);
   digestBoolean(hash, action.zipped);
   hash.update(String(action.web));


### PR DESCRIPTION
Continuation of earlier code cleanup efforts.

1.  Remove remnants of web support.
2.  Remove logic at the end of project reading that checks whether a file system is needed and the `ProjectReader` doesn't have one.  This used to result in cacheing the project locally and re-reading it but the ability to do that was github-specific and the support was already removed so the present code was rotted.

I didn't remove the `ProjectReader` abstraction completely and don't intend to.   There is still logic in the build phase that will fall back on in-memory zipping and throw an error if a real build is needed.   I think this can potentially come back into use when the deployer is invoked as a library in contexts where use of the local file system is impractical.

A question concerns whether to remove support for `cleanNamespace` and the `clean` flags in function and package specifications.   I haven't done it so far.   It does complicate the logic in the deploy phase a fair amount so there is a question of whether it is worth retaining.   These flags are forbidden by AP (which has no use for them since it is always deploying into a fresh empty namespace).    We do not document these flags in the current `project.yml` specification so typical users of `doctl sls deploy` do not know about them.  We provide ways to clean at each of these levels via `doctl sls undeploy` and the UI also has cleaning options.
