### PR TITLE
Fix deployer annotation for correct reporting when the project is in a git clone

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1267,7 +1267,7 @@ export async function getDeployerAnnotation(
 ): Promise<DeployerAnnotation> {
   const digest = undefined;
   try {
-    const git = simplegit();
+    const git = simplegit(project);
     const root = await git.revparse(['--show-toplevel']);
     const repo = await git.raw(['config', '--get', 'remote.origin.url']);
     const user = (await git.raw(['config', '--get', 'user.email'])).trim();


### PR DESCRIPTION
There is a small error in the `getDeployerAnnotation` utility (discovered while I was writing a description of it for the deployer design doc).   It is supposed to report remote repo characteristics when the project is in a git clone.   This was working fine with `doctl sls deploy .` (where the project is in the current directory) but was failing when a different path was used (project not in the current directory).