### PR TITLE
fix: remote-build for python, php and nodejs

### DIFF
--- a/e2e/test_helper.bash
+++ b/e2e/test_helper.bash
@@ -30,7 +30,14 @@ delete_package() {
 init_namespace() {
   $DOCTL auth init --access-token  $DO_API_KEY
   $DOCTL sls install
-  $DOCTL sls connect $TEST_NAMESPACE
+
+  # Check if namespace exists, create if it doesn't
+  if ! $DOCTL sls connect $TEST_NAMESPACE 2>/dev/null; then
+    echo "Namespace $TEST_NAMESPACE not found, creating it..."
+    $DOCTL sls namespaces create --label $TEST_NAMESPACE --region nyc1
+    sleep 10  # Wait for namespace to be ready
+    $DOCTL sls connect $TEST_NAMESPACE
+  fi
 
   CREDS=$($DOCTL sls status --credentials)
   export API_HOST=$(echo "$CREDS" | jq -r .APIHost)

--- a/src/util.ts
+++ b/src/util.ts
@@ -224,16 +224,18 @@ function locateBuild(
   remoteRequired: boolean,
   localRequired: boolean
 ) {
+  // Check for explicit remote build requests first (--remote-build flag or remoteBuild: true)
+  if (remoteRequired || (remoteRequested && !localRequired)) {
+    return 'remote';
+  }
   if (!isRealBuild(buildField)) {
     // Not a real build. Check remote-default conditions.
     if (defaultRemote && !localRequired) {
       return 'remote-default';
     } // else does not meet remote-default conditions
     return buildField;
-  } // else it's a real build. Check conditions for remote.
-  if (remoteRequired || (remoteRequested && !localRequired)) {
-    return 'remote';
-  } // else does not meet conditions for remote
+  }
+  // else does not meet conditions for remote
   return buildField;
 }
 


### PR DESCRIPTION
## Description

Remote builds were not happening for `nodejs`, `python` and `php` even though we mention `--remote-build` flag while deploying a function using `doctl` or `dosls`

The changes in this PR, fixes this problem.

The problem arises when the functions project is getting evaluated to decide if the build needs to take place locally. Unless the functions project has `build.sh` or `build.cwd` or `package.json`, `remote-build` would not be considered for `nodejs`, `python` and `php` runtimed functions.