### PR TITLE
added --ignore-scripts for all npm/yarn installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The `internalRelease.sh` script can also be run with a `--test` flag, in which c
 
 ### Testing changes locally
 
-To test changes locally
+To test changes locally. make sure to add --ignore-scripts flag during install.
 
 ```
-npm install
+npm install --ignore-scripts
 npm run build
 ```
 after which the deployer shell can be run as `/path/to/repo/bin/run`.  It is often convenient to make a symbolic link in your path pointing to that location (e.g. as `dosls`).   Then, you can test with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalocean/functions-deployer",
-  "version": "5.0.22",
+  "version": "5.0.23",
   "description": "The the functions deployer for DigitalOcean",
   "main": "lib/index.js",
   "repository": {

--- a/scripts/packageDosls.sh
+++ b/scripts/packageDosls.sh
@@ -18,7 +18,7 @@ echo "- Removing old artifacts"
 rm -rf lib node_modules *.tgz dosls
 
 echo "- Ensuring a full install"
-npm install --silent --no-progress
+npm install --ignore-scripts --silent --no-progress
 
 echo "- Building the simple tarball"
 npm pack
@@ -27,7 +27,7 @@ echo "- Creating node_modules for the full install"
 mkdir dosls
 cd dosls
 cp ../package.json .
-npm install --production --silent --no-progress ../$TARBALL_NAME
+npm install --ignore-scripts --production --silent --no-progress ../$TARBALL_NAME
 rm *.json
 
 echo "- Downloading node binary suitable for runtime use"

--- a/scripts/packageSandbox.sh
+++ b/scripts/packageSandbox.sh
@@ -13,7 +13,7 @@ echo "- Removing old artifacts"
 rm -rf sandbox *.tar.gz digitalocean-functions-deployer-*.tgz node_modules
 
 echo "- Building the simple deployer tarball"
-npm install
+npm install --ignore-scripts
 npm pack
 
 echo "- Moving artifacts to the sandbox folder"
@@ -31,7 +31,7 @@ fi
 
 echo "$VERSION" > version
 echo "- Installing production dependencies"
-npm install --production
+npm install --ignore-scripts --production
 
 cd ..
 echo "- Creating tar file $TARBALL_NAME"

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -1396,8 +1396,8 @@ function npmBuilder(
   const cmd = flags.yarn ? 'yarn' : 'npm';
   const npmRunBuild = buildScriptExists(filepath);
   const args = npmRunBuild
-    ? ['install', '&&', cmd, 'run', 'build']
-    : ['install', '--production'];
+    ? ['install', '--ignore-scripts', '&&', cmd, 'run', 'build']
+    : ['install', '--ignore-scripts', '--production'];
   const infoMsg = [cmd, ...args].join(' ');
   if (flags.incremental) {
     debug('Detected incremental build');
@@ -1424,7 +1424,7 @@ function npmBuilder(
     filepath,
     displayPath,
     infoMsg,
-    `${cmd} install`,
+    `${cmd} install --ignore-scripts`,
     flags.verboseBuild,
     buildEnv,
     slice,

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,4 +3,4 @@
 // DO NOT EDIT MANUALLY
 ////////////////////////////////////////////////////////////////
 
-export const version = '5.0.22';
+export const version = '5.0.23';


### PR DESCRIPTION
A widespread ongoing NPM supply-chain attack is exploiting the preinstall lifecycle phase to execute malicious code during package installation. Disabling lifecycle scripts prevents any untrusted or compromised packages from executing arbitrary code during npm install / yarn install.

These scripts can:
1. Execute harmful code on your machine or CI/CD servers
2. Create unauthorized GitHub workflow files (.github/workflows/discussion.yaml)
3. Potentially steal tokens, modify repos, inject malware, etc.

Made changes to use npm install --ignore-scripts instead of regular installs.
This prevents execution of preinstall/postinstall lifecycle scripts as part of the ongoing NPM supply-chain security incident.

https://do-internal.atlassian.net/browse/SERVERLESS-3668
