### PR TITLE
update valid runtimes for Go

### DIFF
--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -13,12 +13,12 @@ let cachedRuntimes: RuntimesConfig;
 const staticRuntimes: RuntimesConfig = {
   go: [
     {
-      default: false,
-      kind: 'go:1.15'
-    },
-    {
       default: true,
       kind: 'go:1.17'
+    },
+    {
+      default: false,
+      kind: 'go:1.20'
     }
   ],
   nodejs: [


### PR DESCRIPTION
According to:

- https://docs.digitalocean.com/products/functions/reference/runtimes/
- https://docs.digitalocean.com/products/functions/reference/runtimes/go/

valid Go runtimes for Functions are `go:1.17` and `go:1.20`. Deployed Functions will happily run with a provided `project.yml` value of `go:1.20`, but `doctl serverless get-metadata` will return an error:

```
$ doctl serverless get-metadata .
Error: Invalid project configuration file (project.yml): 'go:1.20' is not a valid runtime value
    Learn more about the project configuration file https://docs.digitalocean.com/products/functions/reference/project-configuration/
```